### PR TITLE
chore: regenerate src from latest Trello OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Build scripts (`scripts/build-og-image`, `scripts/copy-api-to-ru`) migrated from `.mjs` to TypeScript, executed via `tsx`. `tsx` added as a dev dependency.
 - `repository.url` switched to the canonical `git+https://` form so the npm package page can auto-link Issues and Pull Requests against the GitHub repo.
 - npm `description` and `keywords` reworked for discoverability: leads with "type-safe", names Zod 4 explicitly, mentions checklists, and adds high-intent keywords (`javascript`, `nodejs`, `browser`, `atlassian-trello`, `trello-board`, `trello-card`). GitHub repo description and topics aligned to match.
+- Regenerated `src/api`, `src/models`, `src/parameters` from the latest Trello OpenAPI spec via `apis-code-gen`. No public-API changes.
+- `apiObject` re-exported from `#/core` so generated modules can import it from the barrel.
+- JSDoc links to the Trello developer docs rewritten from site-relative (`/cloud/trello/...`) to absolute (`https://developer.atlassian.com/cloud/trello/...`) so they're clickable from IDEs and typedoc.
 
 ## v2.0.0 (2026-05-19)
 

--- a/src/api/boards.ts
+++ b/src/api/boards.ts
@@ -149,8 +149,8 @@ export async function getBoardField<T = unknown>(client: Client, parameters: Get
 }
 
 /**
- * Get all of the actions of a Board. See [Nested Resources](/cloud/trello/guides/rest-api/nested-resources/) for more
- * information.
+ * Get all of the actions of a Board. See [Nested
+ * Resources](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) for more information.
  */
 export async function getBoardActions(client: Client, parameters: GetBoardActions): Promise<Action[]> {
   const config: SendRequestOptions<Action[]> = {
@@ -202,8 +202,8 @@ export async function getBoardChecklists(client: Client, parameters: GetBoardChe
 }
 
 /**
- * Get all of the open Cards on a Board. See [Nested Resources](/cloud/trello/guides/rest-api/nested-resources/) for
- * more information.
+ * Get all of the open Cards on a Board. See [Nested
+ * Resources](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) for more information.
  */
 export async function getBoardCards(client: Client, parameters: GetBoardCards): Promise<Card[]> {
   const config: SendRequestOptions<Card[]> = {
@@ -217,7 +217,7 @@ export async function getBoardCards(client: Client, parameters: GetBoardCards): 
 
 /**
  * Get the Cards on a Board that match a given filter. See [Nested
- * Resources](/cloud/trello/guides/rest-api/nested-resources/) for more information.
+ * Resources](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) for more information.
  */
 export async function getBoardCardsByFilter(client: Client, parameters: GetBoardCardsByFilter): Promise<Card[]> {
   const config: SendRequestOptions<Card[]> = {

--- a/src/api/cards.ts
+++ b/src/api/cards.ts
@@ -171,8 +171,8 @@ export async function getCardField<T = unknown>(client: Client, parameters: GetC
 }
 
 /**
- * List the Actions on a Card. See [Nested Resources](/cloud/trello/guides/rest-api/nested-resources/) for more
- * information.
+ * List the Actions on a Card. See [Nested
+ * Resources](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) for more information.
  */
 export async function getCardActions(client: Client, parameters: GetCardActions): Promise<Action[]> {
   const config: SendRequestOptions<Action[]> = {
@@ -533,7 +533,7 @@ export async function deleteCardComment(client: Client, parameters: DeleteCardCo
 /**
  * Setting, updating, and removing the value for a Custom Field on a card. For more details on updating custom fields
  * check out the [Getting Started With Custom
- * Fields](/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)
+ * Fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)
  */
 export async function updateCardCustomFieldItem(client: Client, parameters: UpdateCardCustomFieldItem): Promise<void> {
   const config: SendRequestOptions<void> = {
@@ -548,7 +548,7 @@ export async function updateCardCustomFieldItem(client: Client, parameters: Upda
 /**
  * Setting, updating, and removing the values for multiple Custom Fields on a card. For more details on updating custom
  * fields check out the [Getting Started With Custom
- * Fields](/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)
+ * Fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)
  */
 export async function updateCardCustomFields(client: Client, parameters: UpdateCardCustomFields): Promise<void> {
   const config: SendRequestOptions<void> = {

--- a/src/batchRunner.ts
+++ b/src/batchRunner.ts
@@ -95,7 +95,9 @@ export function createBatchRunner(realClient: Client) {
     // Suppress unhandled rejections on the namespace function promises (e.g. boards.getBoard(...))
     // — they reject when their inner promise is rejected, but we return innerPromises directly.
     const builderResult = builder(batchClient);
-    builderResult.forEach((p) => { p.catch(() => {}); });
+    builderResult.forEach(p => {
+      p.catch(() => {});
+    });
 
     if (urls.length === 0) return [] as unknown as { -readonly [K in keyof T]: Awaited<T[K]> };
 

--- a/src/core/apiObject.ts
+++ b/src/core/apiObject.ts
@@ -3,12 +3,10 @@ import { z } from 'zod';
 /**
  * Builds an object schema for a Trello API response.
  *
- * By default it strips unknown keys (`z.object`), so a new field added by the
- * Trello API never breaks validation for consumers. When the environment
- * variable `TRELLO_STRICT_SCHEMAS` is set to `'true'` it switches to
- * `z.strictObject`, turning any undocumented key into a `ZodError` — used by
- * this package's own test runs to surface gaps between the schemas and the
- * live API.
+ * By default it strips unknown keys (`z.object`), so a new field added by the Trello API never breaks validation for
+ * consumers. When the environment variable `TRELLO_STRICT_SCHEMAS` is set to `'true'` it switches to `z.strictObject`,
+ * turning any undocumented key into a `ZodError` — used by this package's own test runs to surface gaps between the
+ * schemas and the live API.
  */
 export function apiObject<T extends z.ZodRawShape>(shape: T): z.ZodObject<T> {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,5 @@
+export { apiObject } from './apiObject';
+
 export { buildUrl } from './buildUrl';
 
 export { createBatchRun } from './batchRun';

--- a/src/models/action.ts
+++ b/src/models/action.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { LimitsSchema } from '#/models/limits';
 import { MemberSchema } from '#/models/member';

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { ColorSchema } from '#/models/color';
 import { LimitsSchema } from '#/models/limits';

--- a/src/models/board.ts
+++ b/src/models/board.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { PrefsSchema } from '#/models/prefs';
 import { LimitsSchema } from '#/models/limits';

--- a/src/models/boardBackground.ts
+++ b/src/models/boardBackground.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { ImageDescriptorSchema } from '#/models/imageDescriptor';
 

--- a/src/models/boardMembersResult.ts
+++ b/src/models/boardMembersResult.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { MemberSchema } from '#/models/member';
 import { MembershipsSchema } from '#/models/memberships';
 

--- a/src/models/boardMyPrefs.ts
+++ b/src/models/boardMyPrefs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const BoardMyPrefsSchema = apiObject({
   showSidebar: z.boolean().optional(),

--- a/src/models/boardStars.ts
+++ b/src/models/boardStars.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const BoardStarsSchema = apiObject({

--- a/src/models/cFValue.ts
+++ b/src/models/cFValue.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const CFValueSchema = apiObject({
   number: z.string().optional(),

--- a/src/models/card.ts
+++ b/src/models/card.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { LimitsSchema } from '#/models/limits';
 import { ColorSchema } from '#/models/color';

--- a/src/models/cardSticker.ts
+++ b/src/models/cardSticker.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { ImageDescriptorSchema } from '#/models/imageDescriptor';
 import { LimitsSchema } from '#/models/limits';
 

--- a/src/models/checkItem.ts
+++ b/src/models/checkItem.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { posStringOrNumberSchema } from '#/models/posStringOrNumber';
 import { LimitsSchema } from '#/models/limits';

--- a/src/models/checkItemState.ts
+++ b/src/models/checkItemState.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const CheckItemStateSchema = apiObject({
   idCheckItem: z.string(),

--- a/src/models/checklist.ts
+++ b/src/models/checklist.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { posStringOrNumberSchema } from '#/models/posStringOrNumber';
 import { CheckItemSchema } from '#/models/checkItem';

--- a/src/models/claimableOrganizations.ts
+++ b/src/models/claimableOrganizations.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const ClaimableOrganizationsSchema = apiObject({

--- a/src/models/customEmoji.ts
+++ b/src/models/customEmoji.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const CustomEmojiSchema = apiObject({

--- a/src/models/customField.ts
+++ b/src/models/customField.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const CustomFieldSchema = apiObject({

--- a/src/models/customFieldItemValue.ts
+++ b/src/models/customFieldItemValue.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const customFieldItemValueSchema = apiObject({
   value: apiObject({

--- a/src/models/customFieldItems.ts
+++ b/src/models/customFieldItems.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const CustomFieldItemsSchema = apiObject({

--- a/src/models/customFieldOption.ts
+++ b/src/models/customFieldOption.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const CustomFieldOptionSchema = apiObject({
   _id: z.string(),

--- a/src/models/customSticker.ts
+++ b/src/models/customSticker.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { ImageDescriptorSchema } from '#/models/imageDescriptor';
 import { LimitsSchema } from '#/models/limits';

--- a/src/models/emoji.ts
+++ b/src/models/emoji.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const EmojiSchema = apiObject({
   trello: z

--- a/src/models/enterprise.ts
+++ b/src/models/enterprise.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { OrganizationPrefsSchema } from '#/models/organizationPrefs';
 

--- a/src/models/enterpriseAdmin.ts
+++ b/src/models/enterpriseAdmin.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const EnterpriseAdminSchema = apiObject({

--- a/src/models/enterpriseAuditLog.ts
+++ b/src/models/enterpriseAuditLog.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { OrganizationSchema } from '#/models/organization';
 import { MemberSchema } from '#/models/member';

--- a/src/models/error.ts
+++ b/src/models/error.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const ErrorSchema = apiObject({
   code: z.string(),

--- a/src/models/export.ts
+++ b/src/models/export.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const ExportSchema = apiObject({

--- a/src/models/fieldValue.ts
+++ b/src/models/fieldValue.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const FieldValueSchema = apiObject({
   _value: z.unknown(),

--- a/src/models/getEnterpriseSignUpUrl.ts
+++ b/src/models/getEnterpriseSignUpUrl.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const GetEnterpriseSignUpUrlSchema = apiObject({
   signupUrl: z.string().optional(),

--- a/src/models/imageDescriptor.ts
+++ b/src/models/imageDescriptor.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const ImageDescriptorSchema = apiObject({
   width: z.number().optional(),

--- a/src/models/label.ts
+++ b/src/models/label.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { ColorSchema } from '#/models/color';
 import { LimitsSchema } from '#/models/limits';

--- a/src/models/limitValue.ts
+++ b/src/models/limitValue.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const LimitValueSchema = apiObject({
   status: z.string(),

--- a/src/models/limits.ts
+++ b/src/models/limits.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { LimitValueSchema } from '#/models/limitValue';
 
 export const LimitsSchema = apiObject({

--- a/src/models/limitsObject.ts
+++ b/src/models/limitsObject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const LimitsObjectSchema = apiObject({
   status: z.enum(['ok', 'warning']).optional(),

--- a/src/models/member.ts
+++ b/src/models/member.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { LimitsSchema } from '#/models/limits';
 import { MemberPrefsSchema } from '#/models/memberPrefs';

--- a/src/models/memberPrefs.ts
+++ b/src/models/memberPrefs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const MemberPrefsSchema = apiObject({
   timezoneInfo: apiObject({

--- a/src/models/membership.ts
+++ b/src/models/membership.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { MemberSchema } from '#/models/member';
 
 export const MembershipSchema = apiObject({

--- a/src/models/memberships.ts
+++ b/src/models/memberships.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { MemberSchema } from '#/models/member';
 

--- a/src/models/notification.ts
+++ b/src/models/notification.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { CardSchema } from '#/models/card';
 import { BoardSchema } from '#/models/board';
 import { TrelloIDSchema } from '#/models/trelloID';

--- a/src/models/notificationChannelSettings.ts
+++ b/src/models/notificationChannelSettings.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { BlockedKeySchema } from '#/models/blockedKey';
 import { ChannelSchema } from '#/models/channel';

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { OrganizationPrefsSchema } from '#/models/organizationPrefs';
 import { MembershipsSchema } from '#/models/memberships';

--- a/src/models/organizationPrefs.ts
+++ b/src/models/organizationPrefs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const OrganizationPrefsSchema = apiObject({
   boardVisibilityRestrict: apiObject({

--- a/src/models/pendingOrganizations.ts
+++ b/src/models/pendingOrganizations.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const PendingOrganizationsSchema = apiObject({

--- a/src/models/plugin.ts
+++ b/src/models/plugin.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const PluginSchema = apiObject({

--- a/src/models/pluginData.ts
+++ b/src/models/pluginData.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const PluginDataSchema = apiObject({

--- a/src/models/pluginListing.ts
+++ b/src/models/pluginListing.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const PluginListingSchema = apiObject({

--- a/src/models/prefs.ts
+++ b/src/models/prefs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { CardAgingSchema } from '#/models/cardAging';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { ImageDescriptorSchema } from '#/models/imageDescriptor';

--- a/src/models/reaction.ts
+++ b/src/models/reaction.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { MemberSchema } from '#/models/member';
 
 export const ReactionSchema = apiObject({

--- a/src/models/reactionSummary.ts
+++ b/src/models/reactionSummary.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const ReactionSummarySchema = apiObject({
   id: z.string(),

--- a/src/models/savedSearch.ts
+++ b/src/models/savedSearch.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { posStringOrNumberSchema } from '#/models/posStringOrNumber';
 

--- a/src/models/searchResult.ts
+++ b/src/models/searchResult.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { CardSchema } from '#/models/card';
 import { BoardSchema } from '#/models/board';
 import { MemberSchema } from '#/models/member';

--- a/src/models/switcherView.ts
+++ b/src/models/switcherView.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const SwitcherViewSchema = apiObject({
   viewType: z.string().optional(),

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const TagSchema = apiObject({

--- a/src/models/token.ts
+++ b/src/models/token.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { TokenPermissionSchema } from '#/models/tokenPermission';
 

--- a/src/models/tokenPermission.ts
+++ b/src/models/tokenPermission.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 
 export const TokenPermissionSchema = apiObject({
   idModel: z.union([z.unknown(), z.enum(['*'])]).optional(),

--- a/src/models/transferrableOrganization.ts
+++ b/src/models/transferrableOrganization.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const TransferrableOrganizationSchema = apiObject({

--- a/src/models/trelloList.ts
+++ b/src/models/trelloList.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 import { LimitsSchema } from '#/models/limits';
 

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiObject } from '#/core/apiObject';
+import { apiObject } from '#/core';
 import { TrelloIDSchema } from '#/models/trelloID';
 
 export const WebhookSchema = apiObject({

--- a/src/parameters/createBoard.ts
+++ b/src/parameters/createBoard.ts
@@ -32,10 +32,7 @@ export const CreateBoardSchema = z.object({
   prefsSelfJoin: z.boolean().optional(),
   /** Determines whether card covers are enabled. */
   prefsCardCovers: z.boolean().optional(),
-  /**
-   * The id of a custom background or one of: `blue`, `orange`, `green`, `red`, `purple`, `pink`, `lime`, `sky`,
-   * `grey`.
-   */
+  /** The id of a custom background or one of: `blue`, `orange`, `green`, `red`, `purple`, `pink`, `lime`, `sky`, `grey`. */
   prefsBackground: z.enum(['blue', 'orange', 'green', 'red', 'purple', 'pink', 'lime', 'sky', 'grey']).optional(),
   /**
    * Determines the type of card aging that should take place on the board if card aging is enabled. One of: `pirate`,

--- a/src/parameters/createCardLabel.ts
+++ b/src/parameters/createCardLabel.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const CreateCardLabelSchema = z.object({
   /** The ID of the Card */
   id: z.unknown(),
-  /** A valid label color or `null`. See [labels](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * A valid label color or `null`. See
+   * [labels](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   color: z.string(),
   /** A name for the label */
   name: z.string().optional(),

--- a/src/parameters/createOrganization.ts
+++ b/src/parameters/createOrganization.ts
@@ -7,8 +7,8 @@ export const CreateOrganizationSchema = z.object({
   desc: z.string().optional(),
   /**
    * A string with a length of at least 3. Only lowercase letters, underscores, and numbers are allowed. If the name
-   * contains invalid characters, they will be removed. If the name conflicts with an existing name, a new name will
-   * be substituted.
+   * contains invalid characters, they will be removed. If the name conflicts with an existing name, a new name will be
+   * substituted.
    */
   name: z.string().optional(),
   /** A URL starting with `http://` or `https://` */

--- a/src/parameters/deactivateEnterpriseMember.ts
+++ b/src/parameters/deactivateEnterpriseMember.ts
@@ -9,9 +9,15 @@ export const DeactivateEnterpriseMemberSchema = z.object({
   value: z.boolean(),
   /** A comma separated list of any valid values that the [nested member field resource]() accepts. */
   fields: z.unknown().optional(),
-  /** Any valid value that the [nested organization resource](/cloud/trello/guides/rest-api/nested-resources/) accepts. */
+  /**
+   * Any valid value that the [nested organization
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
+   */
   organizationFields: z.unknown().optional(),
-  /** Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts. */
+  /**
+   * Any valid value that the [nested board
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
+   */
   boardFields: z.unknown().optional(),
 });
 

--- a/src/parameters/getAction.ts
+++ b/src/parameters/getAction.ts
@@ -5,15 +5,21 @@ export const GetActionSchema = z.object({
   entities: z.boolean().optional(),
   /**
    * `all` or a comma-separated list of action
-   * [fields](/cloud/trello/guides/rest-api/object-definitions/#action-object)
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object)
    */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   member: z.boolean().optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   memberFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Whether to include the member object for the creator of the action */
   memberCreator: z.boolean().optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   memberCreatorFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The ID of the Action */
   id: z.unknown(),

--- a/src/parameters/getActionReaction.ts
+++ b/src/parameters/getActionReaction.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const GetActionReactionSchema = z.object({
   /**
    * Whether to load the member as a nested resource. See [Members Nested
-   * Resource](/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)
    */
   member: z.boolean().optional(),
   /** Whether to load the emoji as a nested resource. */

--- a/src/parameters/getActionReactions.ts
+++ b/src/parameters/getActionReactions.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const GetActionReactionsSchema = z.object({
   /**
    * Whether to load the member as a nested resource. See [Members Nested
-   * Resource](/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)
    */
   member: z.boolean().optional(),
   /** Whether to load the emoji as a nested resource. */

--- a/src/parameters/getBoard.ts
+++ b/src/parameters/getBoard.ts
@@ -3,21 +3,21 @@ import { z } from 'zod';
 export const GetBoardSchema = z.object({
   /**
    * This is a nested resource. Read more about actions as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   actions: z.string().optional(),
   /** Valid values are one of: `mine` or `none`. */
   boardStars: z.string().optional(),
   /**
    * This is a nested resource. Read more about cards as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   cards: z.string().optional(),
   /** Use with the `cards` param to include card pluginData with the response */
   cardPluginData: z.boolean().optional(),
   /**
    * This is a nested resource. Read more about checklists as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   checklists: z.string().optional(),
   /**
@@ -27,35 +27,35 @@ export const GetBoardSchema = z.object({
   customFields: z.boolean().optional(),
   /**
    * The fields of the board to be included in the response. Valid values: all or a comma-separated list of: closed,
-   * dateLastActivity, dateLastView, desc, descData, idMemberCreator, idOrganization, invitations, invited,
-   * labelNames, memberships, name, pinned, powerUps, prefs, shortLink, shortUrl, starred, subscribed, url
+   * dateLastActivity, dateLastView, desc, descData, idMemberCreator, idOrganization, invitations, invited, labelNames,
+   * memberships, name, pinned, powerUps, prefs, shortLink, shortUrl, starred, subscribed, url
    */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /**
    * This is a nested resource. Read more about labels as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   labels: z.string().optional(),
   /**
    * This is a nested resource. Read more about lists as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   lists: z.string().optional(),
   /**
    * This is a nested resource. Read more about members as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   members: z.string().optional(),
   /**
    * This is a nested resource. Read more about memberships as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   memberships: z.string().optional(),
   /** Determines whether the pluginData for this board should be returned. Valid values: true or false. */
   pluginData: z.boolean().optional(),
   /**
    * This is a nested resource. Read more about organizations as nested resources
-   * [here](/cloud/trello/guides/rest-api/nested-resources/).
+   * [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   organization: z.boolean().optional(),
   /** Use with the `organization` param to include organization pluginData with the response */

--- a/src/parameters/getBoardActions.ts
+++ b/src/parameters/getBoardActions.ts
@@ -4,10 +4,13 @@ export const GetBoardActionsSchema = z.object({
   boardId: z.string(),
   /**
    * The fields to be returned for the Actions. [See Action fields
-   * here](/cloud/trello/guides/rest-api/object-definitions/#action-object).
+   * here](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object).
    */
   fields: z.unknown().optional(),
-  /** A comma-separated list of [action types](/cloud/trello/guides/rest-api/action-types/). */
+  /**
+   * A comma-separated list of [action
+   * types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).
+   */
   filter: z.union([z.string(), z.array(z.string())]).optional(),
   /** The format of the returned Actions. Either list or count. */
   format: z.string().optional(),
@@ -17,19 +20,27 @@ export const GetBoardActionsSchema = z.object({
   limit: z.number().optional(),
   /** Whether to return the member object for each action. */
   member: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) to return. */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) to
+   * return.
+   */
   memberFields: z.string().optional(),
   /** Whether to return the memberCreator object for each action. */
   memberCreator: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to return */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to
+   * return
+   */
   memberCreatorFields: z.string().optional(),
   /** The page of results for actions. */
   page: z.number().optional(),
   /** Whether to show reactions on comments or not. */
   reactions: z.boolean().optional(),
   /**
-   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date
-   * will be returned.
+   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date will
+   * be returned.
    */
   before: z.string().optional(),
   /**

--- a/src/parameters/getBoardLists.ts
+++ b/src/parameters/getBoardLists.ts
@@ -3,11 +3,17 @@ import { z } from 'zod';
 export const GetBoardListsSchema = z.object({
   /** Filter to apply to Cards. */
   cards: z.unknown().optional(),
-  /** `all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/#card-object) */
+  /**
+   * `all` or a comma-separated list of card
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#card-object)
+   */
   cardFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Filter to apply to Lists */
   filter: z.unknown().optional(),
-  /** `all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of list
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The ID of the board */
   id: z.unknown(),

--- a/src/parameters/getBoardMemberships.ts
+++ b/src/parameters/getBoardMemberships.ts
@@ -7,16 +7,16 @@ export const GetBoardMembershipsSchema = z.object({
   filter: z.enum(['admins', 'all', 'none', 'normal']).optional(),
   /** Works for premium organizations only. */
   activity: z.boolean().optional(),
-  /**
-   * Shows the type of member to the org the user is. For instance, an org admin will have a `orgMemberType` of
-   * `admin`.
-   */
+  /** Shows the type of member to the org the user is. For instance, an org admin will have a `orgMemberType` of `admin`. */
   orgMemberType: z.boolean().optional(),
-  /** Determines whether to include a [nested member object](/cloud/trello/guides/rest-api/nested-resources/). */
+  /**
+   * Determines whether to include a [nested member
+   * object](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
+   */
   member: z.boolean().optional(),
   /**
    * Fields to show if `member=true`. Valid values: [nested member resource
-   * fields](/cloud/trello/guides/rest-api/nested-resources/).
+   * fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/).
    */
   memberFields: z.unknown().optional(),
 });

--- a/src/parameters/getCard.ts
+++ b/src/parameters/getCard.ts
@@ -2,29 +2,38 @@ import { z } from 'zod';
 
 export const GetCardSchema = z.object({
   /**
-   * `all` or a comma-separated list of [fields](/cloud/trello/guides/rest-api/object-definitions/). **Defaults**:
-   * `badges, checkItemStates, closed, dateLastActivity, desc, descData, due, start, idBoard, idChecklists, idLabels,
-   * idList, idMembers, idShort, idAttachmentCover, manualCoverAttachment, labels, name, pos, shortUrl, url`
+   * `all` or a comma-separated list of
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/). **Defaults**: `badges,
+   * checkItemStates, closed, dateLastActivity, desc, descData, due, start, idBoard, idChecklists, idLabels, idList,
+   * idMembers, idShort, idAttachmentCover, manualCoverAttachment, labels, name, pos, shortUrl, url`
    */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
-  /** See the [Actions Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource) */
+  /**
+   * See the [Actions Nested
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource)
+   */
   actions: z.string().optional(),
   /** `true`, `false`, or `cover` */
   attachments: z.union([z.enum(['cover']), z.boolean()]).optional(),
-  /** `all` or a comma-separated list of attachment [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of attachment
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   attachmentFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Whether to return member objects for members on the card */
   members: z.boolean().optional(),
   /**
-   * `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/).
-   * **Defaults**: `avatarHash, fullName, initials, username`
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/). **Defaults**:
+   * `avatarHash, fullName, initials, username`
    */
   memberFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Whether to return member objects for members who voted on the card */
   membersVoted: z.boolean().optional(),
   /**
-   * `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/).
-   * **Defaults**: `avatarHash, fullName, initials, username`
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/). **Defaults**:
+   * `avatarHash, fullName, initials, username`
    */
   memberVotedFields: z.union([z.string(), z.array(z.string())]).optional(),
   checkItemStates: z.boolean().optional(),
@@ -36,17 +45,20 @@ export const GetCardSchema = z.object({
   board: z.boolean().optional(),
   /**
    * `all` or a comma-separated list of board
-   * [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object). **Defaults**: `name, desc, descData,
-   * closed, idOrganization, pinned, url, prefs`
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#board-object).
+   * **Defaults**: `name, desc, descData, closed, idOrganization, pinned, url, prefs`
    */
   boardFields: z.union([z.string(), z.array(z.string())]).optional(),
-  /** See the [Lists Nested Resource](/cloud/trello/guides/rest-api/nested-resources/) */
+  /** See the [Lists Nested Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) */
   list: z.boolean().optional(),
   /** Whether to include pluginData on the card with the response */
   pluginData: z.boolean().optional(),
   /** Whether to include sticker models with the response */
   stickers: z.boolean().optional(),
-  /** `all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of sticker
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   stickerFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Whether to include the customFieldItems */
   customFieldItems: z.boolean().optional(),

--- a/src/parameters/getCardActions.ts
+++ b/src/parameters/getCardActions.ts
@@ -12,7 +12,7 @@ export const GetCardActionsSchema = z.object({
   page: z.number().optional(),
   /**
    * The fields to be returned for the Actions. [See Action fields
-   * here](/cloud/trello/guides/rest-api/object-definitions/#action-object).
+   * here](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object).
    */
   fields: z.unknown().optional(),
   /** The format of the returned Actions. Either list or count. */
@@ -23,17 +23,25 @@ export const GetCardActionsSchema = z.object({
   limit: z.number().optional(),
   /** Whether to return the member object for each action. */
   member: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) to return. */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) to
+   * return.
+   */
   memberFields: z.string().optional(),
   /** Whether to return the memberCreator object for each action. */
   memberCreator: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to return */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to
+   * return
+   */
   memberCreatorFields: z.string().optional(),
   /** Whether to show reactions on comments or not. */
   reactions: z.boolean().optional(),
   /**
-   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date
-   * will be returned.
+   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date will
+   * be returned.
    */
   before: z.string().optional(),
   /**

--- a/src/parameters/getCardAttachments.ts
+++ b/src/parameters/getCardAttachments.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const GetCardAttachmentsSchema = z.object({
-  /** `all` or a comma-separated list of attachment [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of attachment
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Use `cover` to restrict to just the cover attachment */
   filter: z.string().optional(),

--- a/src/parameters/getCardBoard.ts
+++ b/src/parameters/getCardBoard.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetCardBoardSchema = z.object({
   /** The ID of the Card */
   id: z.unknown(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#board-object)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getCardList.ts
+++ b/src/parameters/getCardList.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetCardListSchema = z.object({
   /** The ID of the Card */
   id: z.unknown(),
-  /** `all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of list
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getCardMembers.ts
+++ b/src/parameters/getCardMembers.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetCardMembersSchema = z.object({
   /** The ID of the Card */
   id: z.unknown(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getCardMembersVoted.ts
+++ b/src/parameters/getCardMembersVoted.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const GetCardMembersVotedSchema = z.object({
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The ID of the Card */
   id: z.unknown(),

--- a/src/parameters/getCardSticker.ts
+++ b/src/parameters/getCardSticker.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const GetCardStickerSchema = z.object({
-  /** `all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of sticker
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The ID of the Card */
   id: z.unknown(),

--- a/src/parameters/getCardStickers.ts
+++ b/src/parameters/getCardStickers.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetCardStickersSchema = z.object({
   /** The ID of the Card */
   id: z.unknown(),
-  /** `all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of sticker
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getChecklist.ts
+++ b/src/parameters/getChecklist.ts
@@ -4,19 +4,22 @@ export const GetChecklistSchema = z.object({
   /**
    * Valid values: `all`, `closed`, `none`, `open`, `visible`. Cards is a nested resource. The additional query params
    * available are documented at [Cards Nested
-   * Resource](/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource).
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource).
    */
   cards: z.enum(['all', 'closed', 'none', 'open', 'visible']).optional(),
   /** The check items on the list to return. One of: `all`, `none`. */
   checkItems: z.enum(['all', 'none']).optional(),
   /**
-   * The fields on the checkItem to return if checkItems are being returned. `all` or a comma-separated list of:
-   * `name`, `nameData`, `pos`, `state`, `type`, `due`, `dueReminder`, `idMember`
+   * The fields on the checkItem to return if checkItems are being returned. `all` or a comma-separated list of: `name`,
+   * `nameData`, `pos`, `state`, `type`, `due`, `dueReminder`, `idMember`
    */
   checkItemFields: z
     .enum(['all', 'name', 'nameData', 'pos', 'state', 'type', 'due', 'dueReminder', 'idMember'])
     .optional(),
-  /** `all` or a comma-separated list of checklist [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of checklist
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** ID of a checklist. */
   id: z.unknown(),

--- a/src/parameters/getChecklistBoard.ts
+++ b/src/parameters/getChecklistBoard.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetChecklistBoardSchema = z.object({
   /** ID of a checklist. */
   id: z.unknown(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.enum(['all', 'name']).optional(),
 });
 

--- a/src/parameters/getEnterprise.ts
+++ b/src/parameters/getEnterprise.ts
@@ -4,8 +4,8 @@ export const GetEnterpriseSchema = z.object({
   /** ID of the enterprise to retrieve. */
   id: z.unknown(),
   /**
-   * Comma-separated list of: `id`, `name`, `displayName`, `prefs`, `ssoActivationFailed`, `idAdmins`, `idMembers`
-   * (Note that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be
+   * Comma-separated list of: `id`, `name`, `displayName`, `prefs`, `ssoActivationFailed`, `idAdmins`, `idMembers` (Note
+   * that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be
    * controlled with member_startIndex, etc, but the API response will not contain the total available result count or
    * pagination status data.), `idOrganizations`, `products`, `userTypes`, `idMembers`, `idOrganizations`
    */
@@ -22,13 +22,13 @@ export const GetEnterpriseSchema = z.object({
   /**
    * This parameter expects a SCIM-style sorting value prefixed by a `-` to sort descending. If no `-` is prefixed, it
    * will be sorted ascending. Note that the members array returned will be paginated if `members` is 'normal' or
-   * 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the
-   * total available result count or pagination status data.
+   * 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total
+   * available result count or pagination status data.
    */
   memberSort: z.string().optional(),
   /**
-   * Deprecated: Please use member_sort. This parameter expects a SCIM-style sorting value. Note that the members
-   * array returned will be paginated if `members` is `normal` or `admins`. Pagination can be controlled with
+   * Deprecated: Please use member_sort. This parameter expects a SCIM-style sorting value. Note that the members array
+   * returned will be paginated if `members` is `normal` or `admins`. Pagination can be controlled with
    * `member_startIndex`, etc, and the API response's header will contain the total count and pagination state.
    */
   memberSortBy: z.string().optional(),

--- a/src/parameters/getEnterpriseMember.ts
+++ b/src/parameters/getEnterpriseMember.ts
@@ -8,11 +8,14 @@ export const GetEnterpriseMemberSchema = z.object({
   /** A comma separated list of any valid values that the [nested member field resource]() accepts. */
   fields: z.string().optional(),
   /**
-   * Any valid value that the [nested organization field resource](/cloud/trello/guides/rest-api/nested-resources/)
-   * accepts.
+   * Any valid value that the [nested organization field
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
    */
   organizationFields: z.string().optional(),
-  /** Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts. */
+  /**
+   * Any valid value that the [nested board
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
+   */
   boardFields: z.string().optional(),
 });
 

--- a/src/parameters/getEnterpriseMembers.ts
+++ b/src/parameters/getEnterpriseMembers.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetEnterpriseMembersSchema = z.object({
   /** ID of the Enterprise to retrieve. */
   id: z.unknown(),
-  /** A comma-seperated list of valid [member fields](/cloud/trello/guides/rest-api/object-definitions/#member-object). */
+  /**
+   * A comma-seperated list of valid [member
+   * fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object).
+   */
   fields: z.string().optional(),
   /**
    * Pass a SCIM-style query to filter members. This takes precedence over the all/normal/admins value of members. If
@@ -13,15 +16,15 @@ export const GetEnterpriseMembersSchema = z.object({
   /**
    * This parameter expects a SCIM-style sorting value prefixed by a `-` to sort descending. If no `-` is prefixed, it
    * will be sorted ascending. Note that the members array returned will be paginated if `members` is 'normal' or
-   * 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the
-   * total available result count or pagination status data.
+   * 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total
+   * available result count or pagination status data.
    */
   sort: z.string().optional(),
   /**
    * Deprecated: Please use `sort` instead. This parameter expects a SCIM-style sorting value. Note that the members
    * array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be controlled with
-   * member_startIndex, etc, but the API response will not contain the total available result count or pagination
-   * status data.
+   * member_startIndex, etc, but the API response will not contain the total available result count or pagination status
+   * data.
    */
   sortBy: z.string().optional(),
   /** Deprecated: Please use `sort` instead. One of: `ascending`, `descending`, `asc`, `desc`. */
@@ -31,11 +34,14 @@ export const GetEnterpriseMembersSchema = z.object({
   /** SCIM-style filter. */
   count: z.string().optional(),
   /**
-   * Any valid value that the [nested organization field resource](/cloud/trello/guides/rest-api/nested-resources/)
-   * accepts.
+   * Any valid value that the [nested organization field
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
    */
   organizationFields: z.string().optional(),
-  /** Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts. */
+  /**
+   * Any valid value that the [nested board
+   * resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/) accepts.
+   */
   boardFields: z.string().optional(),
 });
 

--- a/src/parameters/getEnterpriseOrganizations.ts
+++ b/src/parameters/getEnterpriseOrganizations.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetEnterpriseOrganizationsSchema = z.object({
   /** ID of the Enterprise to retrieve. */
   id: z.unknown(),
-  /** Comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * Comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
   filter: z.string().optional(),
   /** Any integer greater than and equal to 1. */

--- a/src/parameters/getEnterpriseSignUpUrl.ts
+++ b/src/parameters/getEnterpriseSignUpUrl.ts
@@ -8,8 +8,8 @@ export const GetEnterpriseSignUpUrlSchema = z.object({
   /** Any valid URL. */
   returnUrl: z.string().optional(),
   /**
-   * Designates whether the user has seen/consented to the Trello ToS prior to being redirected to the enterprise
-   * signup page/their IdP.
+   * Designates whether the user has seen/consented to the Trello ToS prior to being redirected to the enterprise signup
+   * page/their IdP.
    */
   tosAccepted: z.boolean().optional(),
 });

--- a/src/parameters/getLabel.ts
+++ b/src/parameters/getLabel.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 export const GetLabelSchema = z.object({
-  /** All or a comma-separated list of [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * All or a comma-separated list of
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The ID of the Label */
   id: z.unknown(),

--- a/src/parameters/getListActions.ts
+++ b/src/parameters/getListActions.ts
@@ -10,7 +10,7 @@ export const GetListActionsSchema = z.object({
   filter: z.union([z.string(), z.array(z.string())]).optional(),
   /**
    * The fields to be returned for the Actions. [See Action fields
-   * here](/cloud/trello/guides/rest-api/object-definitions/#action-object).
+   * here](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object).
    */
   fields: z.unknown().optional(),
   /** The format of the returned Actions. Either list or count. */
@@ -21,19 +21,27 @@ export const GetListActionsSchema = z.object({
   limit: z.number().optional(),
   /** Whether to return the member object for each action. */
   member: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) to return. */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) to
+   * return.
+   */
   memberFields: z.string().optional(),
   /** Whether to return the memberCreator object for each action. */
   memberCreator: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to return */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to
+   * return
+   */
   memberCreatorFields: z.string().optional(),
   /** The page of results for actions. */
   page: z.number().optional(),
   /** Whether to show reactions on comments or not. */
   reactions: z.boolean().optional(),
   /**
-   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date
-   * will be returned.
+   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date will
+   * be returned.
    */
   before: z.string().optional(),
   /**

--- a/src/parameters/getListBoard.ts
+++ b/src/parameters/getListBoard.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetListBoardSchema = z.object({
   /** The ID of the list */
   id: z.string(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#board-object)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getMember.ts
+++ b/src/parameters/getMember.ts
@@ -3,9 +3,15 @@ import { z } from 'zod';
 export const GetMemberSchema = z.object({
   /** The ID or username of the member */
   id: z.union([z.unknown(), z.string()]),
-  /** See the [Actions Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource) */
+  /**
+   * See the [Actions Nested
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource)
+   */
   actions: z.string().optional(),
-  /** See the [Boards Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#boards-nested-resource) */
+  /**
+   * See the [Boards Nested
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#boards-nested-resource)
+   */
   boards: z.string().optional(),
   /** One of: `all`, `custom`, `default`, `none`, `premium` */
   boardBackgrounds: z.enum(['all', 'custom', 'default', 'none', 'premium']).optional(),
@@ -13,12 +19,16 @@ export const GetMemberSchema = z.object({
   boardsInvited: z
     .enum(['closed', 'members', 'open', 'organization', 'pinned', 'public', 'starred', 'unpinned'])
     .optional(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   boardsInvitedFields: z.unknown().optional(),
   /** Whether to return the boardStars or not */
   boardStars: z.boolean().optional(),
   /**
-   * See the [Cards Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource) for
+   * See the [Cards Nested
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource) for
    * additional options
    */
   cards: z.string().optional(),
@@ -28,22 +38,31 @@ export const GetMemberSchema = z.object({
   customEmoji: z.enum(['all', 'none']).optional(),
   /** `all` or `none` */
   customStickers: z.enum(['all', 'none']).optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
   /**
    * See the [Notifications Nested
-   * Resource](/cloud/trello/guides/rest-api/nested-resources/#notifications-nested-resource)
+   * Resource](https://developer.atlassian.com/cloud/trello/guides/rest-api/nested-resources/#notifications-nested-resource)
    */
   notifications: z.string().optional(),
   /** One of: `all`, `members`, `none`, `public` */
   organizations: z.enum(['all', 'members', 'none', 'public']).optional(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   organizationFields: z.unknown().optional(),
   /** Whether or not to include paid account information in the returned workspace object */
   organizationPaidAccount: z.boolean().optional(),
   /** One of: `all`, `members`, `none`, `public` */
   organizationsInvited: z.enum(['all', 'members', 'none', 'public']).optional(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   organizationsInvitedFields: z.unknown().optional(),
   /** Whether or not to include paid account information in the returned member object */
   paidAccount: z.boolean().optional(),

--- a/src/parameters/getMemberActions.ts
+++ b/src/parameters/getMemberActions.ts
@@ -10,7 +10,7 @@ export const GetMemberActionsSchema = z.object({
   filter: z.union([z.string(), z.array(z.string())]).optional(),
   /**
    * The fields to be returned for the Actions. [See Action fields
-   * here](/cloud/trello/guides/rest-api/object-definitions/#action-object).
+   * here](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object).
    */
   fields: z.unknown().optional(),
   /** The format of the returned Actions. Either list or count. */
@@ -21,19 +21,27 @@ export const GetMemberActionsSchema = z.object({
   limit: z.number().optional(),
   /** Whether to return the member object for each action. */
   member: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) to return. */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) to
+   * return.
+   */
   memberFields: z.string().optional(),
   /** Whether to return the memberCreator object for each action. */
   memberCreator: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to return */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to
+   * return
+   */
   memberCreatorFields: z.string().optional(),
   /** The page of results for actions. */
   page: z.number().optional(),
   /** Whether to show reactions on comments or not. */
   reactions: z.boolean().optional(),
   /**
-   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date
-   * will be returned.
+   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date will
+   * be returned.
    */
   before: z.string().optional(),
   /**

--- a/src/parameters/getMemberBoards.ts
+++ b/src/parameters/getMemberBoards.ts
@@ -5,13 +5,19 @@ export const GetMemberBoardsSchema = z.object({
   id: z.unknown(),
   /** `all` or a comma-separated list of: `closed`, `members`, `open`, `organization`, `public`, `starred` */
   filter: z.enum(['all', 'closed', 'members', 'open', 'organization', 'public', 'starred']).optional(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
   /** Which lists to include with the boards. One of: `all`, `closed`, `none`, `open` */
   lists: z.enum(['all', 'closed', 'none', 'open']).optional(),
   /** Whether to include the Organization object with the Boards */
   organization: z.boolean().optional(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   organizationFields: z.unknown().optional(),
 });
 

--- a/src/parameters/getMemberField.ts
+++ b/src/parameters/getMemberField.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const GetMemberFieldSchema = z.object({
   /** The ID or username of the member */
   id: z.unknown(),
-  /** One of the member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /** One of the member [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/) */
   field: z.unknown(),
 });
 

--- a/src/parameters/getMemberInvitedBoards.ts
+++ b/src/parameters/getMemberInvitedBoards.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetMemberInvitedBoardsSchema = z.object({
   /** The ID or username of the member */
   id: z.unknown(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getMemberInvitedOrganizations.ts
+++ b/src/parameters/getMemberInvitedOrganizations.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetMemberInvitedOrganizationsSchema = z.object({
   /** The ID or username of the member */
   id: z.unknown(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getMemberNotifications.ts
+++ b/src/parameters/getMemberNotifications.ts
@@ -8,7 +8,10 @@ export const GetMemberNotificationsSchema = z.object({
   filter: z.string().optional(),
   /** One of: `all`, `read`, `unread` */
   readFilter: z.string().optional(),
-  /** `all` or a comma-separated list of notification [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of notification
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.union([z.string(), z.array(z.string())]).optional(),
   /** Max 1000 */
   limit: z.number().optional(),
@@ -19,7 +22,10 @@ export const GetMemberNotificationsSchema = z.object({
   /** A notification ID */
   since: z.string().optional(),
   memberCreator: z.boolean().optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   memberCreatorFields: z.union([z.string(), z.array(z.string())]).optional(),
 });
 

--- a/src/parameters/getMemberOrganizations.ts
+++ b/src/parameters/getMemberOrganizations.ts
@@ -5,7 +5,10 @@ export const GetMemberOrganizationsSchema = z.object({
   id: z.unknown(),
   /** One of: `all`, `members`, `none`, `public` (Note: `members` filters to only private Workspaces) */
   filter: z.enum(['all', 'members', 'none', 'public']).optional(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
   /** Whether or not to include paid account information in the returned workspace object */
   paidAccount: z.boolean().optional(),

--- a/src/parameters/getNotification.ts
+++ b/src/parameters/getNotification.ts
@@ -5,31 +5,49 @@ export const GetNotificationSchema = z.object({
   id: z.unknown(),
   /** Whether to include the board object */
   board: z.boolean().optional(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   boardFields: z.unknown().optional(),
   /** Whether to include the card object */
   card: z.boolean().optional(),
-  /** `all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of card
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   cardFields: z.unknown().optional(),
   /** Whether to include the display object with the results */
   display: z.boolean().optional(),
   /** Whether to include the entities object with the results */
   entities: z.boolean().optional(),
-  /** `all` or a comma-separated list of notification [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of notification
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
   /** Whether to include the list object */
   list: z.boolean().optional(),
   /** Whether to include the member object */
   member: z.boolean().optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   memberFields: z.unknown().optional(),
   /** Whether to include the member object of the creator */
   memberCreator: z.boolean().optional(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   memberCreatorFields: z.unknown().optional(),
   /** Whether to include the organization object */
   organization: z.boolean().optional(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   organizationFields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationBoard.ts
+++ b/src/parameters/getNotificationBoard.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationBoardSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of board[fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of
+   * board[fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationCard.ts
+++ b/src/parameters/getNotificationCard.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationCardSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of card
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationCreator.ts
+++ b/src/parameters/getNotificationCreator.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationCreatorSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationField.ts
+++ b/src/parameters/getNotificationField.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const GetNotificationFieldSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** A notification [field](/cloud/trello/guides/rest-api/object-definitions/) */
+  /** A notification [field](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/) */
   field: z.unknown(),
 });
 

--- a/src/parameters/getNotificationList.ts
+++ b/src/parameters/getNotificationList.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationListSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of list
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationMember.ts
+++ b/src/parameters/getNotificationMember.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationMemberSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of member
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getNotificationOrganization.ts
+++ b/src/parameters/getNotificationOrganization.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const GetNotificationOrganizationSchema = z.object({
   /** The ID of the notification */
   id: z.unknown(),
-  /** `all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of organization
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.unknown().optional(),
 });
 

--- a/src/parameters/getOrganizationActions.ts
+++ b/src/parameters/getOrganizationActions.ts
@@ -5,10 +5,13 @@ export const GetOrganizationActionsSchema = z.object({
   id: z.unknown(),
   /**
    * The fields to be returned for the Actions. [See Action fields
-   * here](/cloud/trello/guides/rest-api/object-definitions/#action-object).
+   * here](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#action-object).
    */
   fields: z.unknown().optional(),
-  /** A comma-separated list of [action types](/cloud/trello/guides/rest-api/action-types/). */
+  /**
+   * A comma-separated list of [action
+   * types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).
+   */
   filter: z.union([z.string(), z.array(z.string())]).optional(),
   /** The format of the returned Actions. Either list or count. */
   format: z.string().optional(),
@@ -18,19 +21,27 @@ export const GetOrganizationActionsSchema = z.object({
   limit: z.number().optional(),
   /** Whether to return the member object for each action. */
   member: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) to return. */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) to
+   * return.
+   */
   memberFields: z.string().optional(),
   /** Whether to return the memberCreator object for each action. */
   memberCreator: z.boolean().optional(),
-  /** The fields of the [member](/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to return */
+  /**
+   * The fields of the
+   * [member](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/#member-object) creator to
+   * return
+   */
   memberCreatorFields: z.string().optional(),
   /** The page of results for actions. */
   page: z.number().optional(),
   /** Whether to show reactions on comments or not. */
   reactions: z.boolean().optional(),
   /**
-   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date
-   * will be returned.
+   * A date string in the form of YYYY-MM-DDThh:mm:ssZ or a mongo object ID. Only objects created before this date will
+   * be returned.
    */
   before: z.string().optional(),
   /**

--- a/src/parameters/getOrganizationBoards.ts
+++ b/src/parameters/getOrganizationBoards.ts
@@ -5,7 +5,10 @@ export const GetOrganizationBoardsSchema = z.object({
   id: z.unknown(),
   /** `all` or a comma-separated list of: `open`, `closed`, `members`, `organization`, `public` */
   filter: z.enum(['all', 'open', 'closed', 'members', 'organization', 'public']).optional(),
-  /** `all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/) */
+  /**
+   * `all` or a comma-separated list of board
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/)
+   */
   fields: z.string().optional(),
 });
 

--- a/src/parameters/getOrganizationField.ts
+++ b/src/parameters/getOrganizationField.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const GetOrganizationFieldSchema = z.object({
   /** The ID or name of the organization */
   id: z.unknown(),
-  /** An organization [field](/cloud/trello/guides/rest-api/object-definitions/) */
+  /** An organization [field](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/) */
   field: z.unknown(),
 });
 

--- a/src/parameters/getTokenMember.ts
+++ b/src/parameters/getTokenMember.ts
@@ -4,7 +4,7 @@ export const GetTokenMemberSchema = z.object({
   token: z.string(),
   /**
    * `all` or a comma-separated list of valid fields for [Member
-   * Object](/cloud/trello/guides/rest-api/object-definitions/).
+   * Object](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/).
    */
   fields: z.unknown().optional(),
 });

--- a/src/parameters/getUser.ts
+++ b/src/parameters/getUser.ts
@@ -14,14 +14,14 @@ export const GetUserSchema = z.object({
    */
   deactivated: z.boolean().optional(),
   /**
-   * When true, returns members who are guests on one or more boards in the corresponding Trello Enterprise (but do
-   * not possess a license); when false, returns members who are not. If unspecified, both guests and non-guests will
-   * be returned.
+   * When true, returns members who are guests on one or more boards in the corresponding Trello Enterprise (but do not
+   * possess a license); when false, returns members who are not. If unspecified, both guests and non-guests will be
+   * returned.
    */
   collaborator: z.boolean().optional(),
   /**
-   * When true, returns members who are managed by the corresponding Trello Enterprise; when false, returns members
-   * who are not. If unspecified, both managed and unmanaged members will be returned.
+   * When true, returns members who are managed by the corresponding Trello Enterprise; when false, returns members who
+   * are not. If unspecified, both managed and unmanaged members will be returned.
    */
   managed: z.boolean().optional(),
   /**

--- a/src/parameters/inviteBoardMember.ts
+++ b/src/parameters/inviteBoardMember.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 export const InviteBoardMemberSchema = z.object({
   /** The email address of a user to add as a member of the board. */
   email: z.string(),
-  /**
-   * Valid values: admin, normal, observer. Determines what type of member the user being added should be of the
-   * board.
-   */
+  /** Valid values: admin, normal, observer. Determines what type of member the user being added should be of the board. */
   type: z.enum(['admin', 'normal', 'observer']).optional(),
   /** The ID of the board */
   id: z.unknown(),

--- a/src/parameters/markAllNotificationsRead.ts
+++ b/src/parameters/markAllNotificationsRead.ts
@@ -6,8 +6,8 @@ export const MarkAllNotificationsReadSchema = z.object({
   read: z.boolean().optional(),
   /**
    * A comma-seperated list of IDs. Allows specifying an array of notification IDs to change the read state for. This
-   * will become useful as we add grouping of notifications to the UI, with a single button to mark all notifications
-   * in the group as read/unread.
+   * will become useful as we add grouping of notifications to the UI, with a single button to mark all notifications in
+   * the group as read/unread.
    */
   ids: z.array(TrelloIDSchema).optional(),
 });

--- a/src/parameters/search.ts
+++ b/src/parameters/search.ts
@@ -48,8 +48,8 @@ export const SearchSchema = z.object({
    */
   cardAttachments: z.string().optional(),
   /**
-   * All or a comma-separated list of billableMemberCount, desc, descData, displayName, idBoards, invitations,
-   * invited, logoHash, memberships, name, powerUps, prefs, premiumFeatures, products, url, website
+   * All or a comma-separated list of billableMemberCount, desc, descData, displayName, idBoards, invitations, invited,
+   * logoHash, memberships, name, powerUps, prefs, premiumFeatures, products, url, website
    */
   organizationFields: z.union([z.string(), z.array(z.string())]).optional(),
   /** The maximum number of Workspaces to return. Maximum 1000 */
@@ -63,9 +63,9 @@ export const SearchSchema = z.object({
   membersLimit: z.number().optional(),
   /**
    * By default, Trello searches for each word in your query against exactly matching words within Member content.
-   * Specifying partial to be true means that we will look for content that starts with any of the words in your
-   * query. If you are looking for a Card titled "My Development Status Report", by default you would need to search
-   * for "Development". If you have partial enabled, you will be able to search for "dev" but not "velopment".
+   * Specifying partial to be true means that we will look for content that starts with any of the words in your query.
+   * If you are looking for a Card titled "My Development Status Report", by default you would need to search for
+   * "Development". If you have partial enabled, you will be able to search for "dev" but not "velopment".
    */
   partial: z.boolean().optional(),
 });

--- a/src/parameters/updateBoardMembership.ts
+++ b/src/parameters/updateBoardMembership.ts
@@ -8,8 +8,8 @@ export const UpdateBoardMembershipSchema = z.object({
   /** One of: admin, normal, observer. Determines the type of member that this membership will be to this board. */
   type: z.enum(['admin', 'normal', 'observer']),
   /**
-   * Valid values: all, avatarHash, bio, bioData, confirmed, fullName, idPremOrgsAdmin, initials, memberType,
-   * products, status, url, username
+   * Valid values: all, avatarHash, bio, bioData, confirmed, fullName, idPremOrgsAdmin, initials, memberType, products,
+   * status, url, username
    */
   memberFields: z
     .enum([

--- a/src/parameters/updateCard.ts
+++ b/src/parameters/updateCard.ts
@@ -36,26 +36,29 @@ export const UpdateCardSchema = z.object({
   /**
    * Updates the card's cover | Option | Values | About | |--------|--------|-------| | color | `pink`, `yellow`,
    * `lime`, `blue`, `black`, `orange`, `red`, `purple`, `sky`, `green` | Makes the cover a solid color . | |
-   * brightness | `dark`, `light` | Determines whether the text on the cover should be dark or light. | url | An
-   * unsplash URL: https://images.unsplash.com | Used if making an image the cover. Only Unsplash URLs work. |
-   * idAttachment | ID of an attachment on the card | Used if setting an attached image as the cover. | | size |
-   * `normal`, `full` | Determines whether to show the card name on the cover, or below it. |
+   * brightness
+   *
+   * | `dark`, `light` | Determines whether the text on the cover should be dark or light. | url | An unsplash URL:
+   *
+   * https://images.unsplash.com | Used if making an image the cover. Only Unsplash URLs work. | idAttachment | ID of an
+   * attachment on the card | Used if setting an attached image as the cover. | | size | `normal`, `full` | Determines
+   * whether to show the card name on the cover, or below it. |
    *
    * `brightness` can be sent alongside any of the other parameters, but all of the other parameters are mutually
    * exclusive; you can not have the cover be a `color` and an `idAttachment` at the same time.
    *
    * On the brightness options, setting it to light will make the text on the card cover dark:
-   * [](/cloud/trello/images/rest/cards/cover-brightness-dark.png)
+   * [](https://developer.atlassian.com/cloud/trello/images/rest/cards/cover-brightness-dark.png)
    *
    * And vice versa, setting it to dark will make the text on the card cover light:
-   * [](/cloud/trello/images/rest/cards/cover-brightness-light.png)
+   * [](https://developer.atlassian.com/cloud/trello/images/rest/cards/cover-brightness-light.png)
    */
   cover: z
     .object({
       /**
-       * An object containing information regarding the card's cover `brightness` can be sent alongside any of the
-       * other parameters, but all of the other parameters are mutually exclusive; you can not have the cover be a
-       * color and an `idAttachment` at the same time.
+       * An object containing information regarding the card's cover `brightness` can be sent alongside any of the other
+       * parameters, but all of the other parameters are mutually exclusive; you can not have the cover be a color and
+       * an `idAttachment` at the same time.
        */
       value: z
         .object({
@@ -64,9 +67,8 @@ export const UpdateCardSchema = z.object({
             .enum(['pink', 'yellow', 'lime', 'blue', 'black', 'orange', 'red', 'purple', 'sky', 'green'])
             .optional(),
           /**
-           * Determines whether the text on the cover should be dark or light. Setting it to `light` will make the
-           * text on the card cover dark. And vice versa, setting it to dark will make the text on the card cover
-           * light
+           * Determines whether the text on the cover should be dark or light. Setting it to `light` will make the text
+           * on the card cover dark. And vice versa, setting it to dark will make the text on the card cover light
            */
           brightness: z.enum(['dark', 'light']).optional(),
           /** Used if making an image the cover. Only Unsplash URLs (https://images.unsplash.com/) work. */

--- a/src/parameters/updateLabel.ts
+++ b/src/parameters/updateLabel.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const UpdateLabelSchema = z.object({
   /** The new name for the label */
   name: z.string().optional(),
-  /** The new color for the label. See: [fields](/cloud/trello/guides/rest-api/object-definitions/) for color options */
+  /**
+   * The new color for the label. See:
+   * [fields](https://developer.atlassian.com/cloud/trello/guides/rest-api/object-definitions/) for color options
+   */
   color: z.unknown().optional(),
   /** The ID of the Label */
   id: z.unknown(),

--- a/src/parameters/updateMember.ts
+++ b/src/parameters/updateMember.ts
@@ -8,8 +8,8 @@ export const UpdateMemberSchema = z.object({
   /** New initials for the member. 1-4 characters long. */
   initials: z.string().max(4, 'initials must be at most 4 characters').optional(),
   /**
-   * New username for the member. At least 3 characters long, only lowercase letters, underscores, and numbers. Must
-   * be unique.
+   * New username for the member. At least 3 characters long, only lowercase letters, underscores, and numbers. Must be
+   * unique.
    */
   username: z.string().optional(),
   bio: z.string().optional(),


### PR DESCRIPTION
## Summary

Re-runs the [apis-code-gen](https://github.com/MrRefactoring/apis-code-gen) pipeline against the current Trello swagger and syncs the generated directories (`src/api`, `src/models`, `src/parameters`).

**No public-API changes.** The generator's recent heuristics (contentless `200` → `void`, parameter `format: date-time` → `Date | string`) were neutralized by trello-specific swagger patches in apis-code-gen so `batch.run`, `getOrganizationNewBillableGuests`, and `updateCardCustomFields.value.date` keep their v2.0.0 surface.

### Cosmetic / structural

- `apiObject` re-exported from `#/core` so generated modules resolve it from the barrel instead of the deep path `#/core/apiObject`.
- `prettier --write` picked up pre-existing drift in `src/batchRunner.ts` and `src/core/apiObject.ts` (formatting only).

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm vitest run` — 71/71 passing, API contract snapshot unchanged