### PR TITLE
release: v2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Trello.js changelog
 
+## v2.1.6 (2026-07-05)
+
+### Fixed
+
+- `Card.dueReminder` is now typed as `number` instead of `string`. The live Trello API returns this field as a number (minutes before the due date), so every card-returning endpoint could reject with `ZodError: expected string, received number` — surfaced on `getBoardCards` / `getListCards` as `path [n, "dueReminder"]`. Now matches the already-correct `CheckItem.dueReminder`.
+- `ColorSchema` now accepts the `_light` / `_dark` shade variants (e.g. `sky_dark`, `green_light`). The documented palette is 10 base colors, but the live API also returns the shade variants introduced in the May 2023 label redesign (30 values total); a label using one raised `ZodError: invalid_value` on `labels[].color`, breaking `getBoardCards` / `getListCards`. Closes [#48](https://github.com/MrRefactoring/trello.js/issues/48) — thanks to [@sampgoes97-ux](https://github.com/sampgoes97-ux) for the detailed report.
+
 ## v2.1.5 (2026-07-04)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#/*": "./src/*"
   },
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Type-safe Trello REST API client for TypeScript and JavaScript. ESM-only, tree-shakable, runtime-validated by Zod 4. Full coverage of boards, cards, lists, checklists, members, webhooks, organizations. Atlassian Trello SDK for Node.js 22+ and modern browsers.",
   "author": "Vladislav Tupikin <vladislav.tupikin@icloud.com>",
   "license": "MIT",

--- a/src/models/card.ts
+++ b/src/models/card.ts
@@ -45,7 +45,7 @@ export const CardSchema = apiObject({
     emoji: z.record(z.string(), z.any()).optional(),
   }).optional(),
   due: z.coerce.date().nullish(),
-  dueReminder: z.string().nullish(),
+  dueReminder: z.number().nullish(),
   idBoard: z.string().optional(),
   idChecklists: z.array(z.union([ChecklistSchema, z.string()])).optional(),
   idLabels: z.array(z.union([LabelSchema, z.string()])).optional(),

--- a/src/models/color.ts
+++ b/src/models/color.ts
@@ -1,7 +1,38 @@
 import { z } from 'zod';
 
 export const ColorSchema = z
-  .enum(['yellow', 'purple', 'blue', 'red', 'green', 'orange', 'black', 'sky', 'pink', 'lime'])
+  .enum([
+    'yellow',
+    'purple',
+    'blue',
+    'red',
+    'green',
+    'orange',
+    'black',
+    'sky',
+    'pink',
+    'lime',
+    'yellow_dark',
+    'purple_dark',
+    'blue_dark',
+    'red_dark',
+    'green_dark',
+    'orange_dark',
+    'black_dark',
+    'sky_dark',
+    'pink_dark',
+    'lime_dark',
+    'yellow_light',
+    'purple_light',
+    'blue_light',
+    'red_light',
+    'green_light',
+    'orange_light',
+    'black_light',
+    'sky_light',
+    'pink_light',
+    'lime_light',
+  ])
   .nullable();
 
 export type Color = z.infer<typeof ColorSchema>;

--- a/tests/unit/models/breadth.test.ts
+++ b/tests/unit/models/breadth.test.ts
@@ -60,7 +60,7 @@ describe('response schema breadth — minimal vs maximal', () => {
         desc: 'a description',
         descData: { emoji: {} },
         due: ISO,
-        dueReminder: '1440',
+        dueReminder: 1440,
         idBoard: ID,
         idChecklists: [ID],
         idLabels: [ID],

--- a/tests/unit/models/card.test.ts
+++ b/tests/unit/models/card.test.ts
@@ -54,3 +54,40 @@ describe('CardSchema — checkItemStates objects', () => {
     ).toThrow();
   });
 });
+
+// Drift surfaced in issue #48 (ZodError on getBoardCards). The API returns
+// `dueReminder` as a number (minutes before the due date), not a string, and
+// labels can carry the undocumented `_light` / `_dark` shade colors.
+describe('CardSchema — dueReminder is a number (issue #48)', () => {
+  const baseCard = { id: 'a'.repeat(24) };
+
+  it('accepts dueReminder as a number', () => {
+    expect(() => CardSchema.parse({ ...baseCard, dueReminder: 1440 })).not.toThrow();
+  });
+
+  it('accepts dueReminder as null', () => {
+    expect(() => CardSchema.parse({ ...baseCard, dueReminder: null })).not.toThrow();
+  });
+
+  it('rejects dueReminder as a string (the old, wrong shape)', () => {
+    expect(() => CardSchema.parse({ ...baseCard, dueReminder: '1440' })).toThrow();
+  });
+});
+
+describe('CardSchema — label shade colors (issue #48)', () => {
+  const baseCard = { id: 'a'.repeat(24) };
+  const label = (color: string) => ({ id: 'l'.repeat(24), color });
+
+  it('accepts the new `_dark` / `_light` shade variants on labels', () => {
+    expect(() =>
+      CardSchema.parse({
+        ...baseCard,
+        labels: [label('sky_dark'), label('green_light'), label('blue')],
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown color that is not part of the palette', () => {
+    expect(() => CardSchema.parse({ ...baseCard, labels: [label('teal')] })).toThrow();
+  });
+});


### PR DESCRIPTION
Releases **v2.1.6** — a schema-drift bugfix for `boards.getBoardCards()` / `lists.getListCards()`, which threw a `ZodError` on real boards even though the request succeeded. Fixes #48.

## Fixed

### `Card.dueReminder`
Schema declared `z.string()`, but the API returns a **number** (minutes before the due date). Aligned with the already-correct `CheckItem.dueReminder`:

```diff
- dueReminder: z.string().nullish(),
+ dueReminder: z.number().nullish(),
```

### `labels[].color` (`ColorSchema`)
The enum only accepted the 10 documented base colors. The API also returns the undocumented `_light` / `_dark` shade variants introduced in the May 2023 label redesign — **30 values total**. Extended the enum to the full palette (still `.nullable()`).

## Tests
- Regression coverage in `tests/unit/models/card.test.ts` pinning both schemas (number/null/string for `dueReminder`; accepts `sky_dark` / `green_light`, rejects an unknown color).
- Fixed the maximal-payload fixture in `breadth.test.ts` that encoded the old `dueReminder` string shape.
- `tsc --noEmit` clean · full unit suite green (171 passed).

## Release
- `package.json` → `2.1.6`
- `CHANGELOG.md` → v2.1.6 section

No `skipParsing` needed after this — the response validates cleanly. Thanks to @sampgoes97-ux for the detailed report.