### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Trello.js changelog
 
-## Unreleased
+## v2.2.0 (2026-08-20)
+
+**Read this one if you `switch` exhaustively over a value this client returns.** The enum-shaped types are now open, `Color` and `CardAging` among them, so a `switch` with no `default` branch stops type-checking. That ships in a minor release on purpose: the values belong to Trello, not to this client. The `_light` / `_dark` label shades reached the live API long before the spec named them and broke `getBoardCards` for every consumer until v2.1.6 added the 30 values by hand, so a closed set was never a promise a wrapper could keep.
 
 ### Fixed
 
 - `Organization` gained `iconEmoji`, `iconEmojiBackground` and `eligibleForTrial`. The live API returns all three on every workspace; they were silently stripped in normal mode and raised `ZodError: unrecognized_keys` in strict/audit mode (`pnpm audit:schemas`), breaking `getMemberOrganizations` and the organization-returning endpoints. `eligibleForTrial` is a boolean; the two icon fields are typed `unknown` because every workspace reachable from this account reports them as `null`, so their populated shape is still unobserved.
 
-### Removed
+### Deprecated
 
-- **`PerformBatch` / `PerformBatchSchema` removed from `trello.js/parameters`.** An orphan: nothing referenced it, and the batch endpoint takes `Run`.
+- **`PerformBatch` / `PerformBatchSchema` in `trello.js/parameters` are now aliases of `Run` / `RunSchema`.** Both names describe the same `{ urls: string }` body, both keep the `@deprecated` mark they have carried since v2.1.2, and both go at the next major version. The batch endpoint takes `Run`.
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#/*": "./src/*"
   },
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Type-safe Trello REST API client for TypeScript and JavaScript. ESM-only, tree-shakable, runtime-validated by Zod 4. Full coverage of boards, cards, lists, checklists, members, webhooks, organizations. Atlassian Trello SDK for Node.js 22+ and modern browsers.",
   "author": "Vladislav Tupikin <vladislav.tupikin@icloud.com>",
   "license": "MIT",

--- a/src/parameters/index.ts
+++ b/src/parameters/index.ts
@@ -392,6 +392,8 @@ export * from './moveAllListCards';
 
 export * from './moveListToBoard';
 
+export * from './performBatch';
+
 export * from './removeBoardMember';
 
 export * from './removeCardChecklist';

--- a/src/parameters/performBatch.ts
+++ b/src/parameters/performBatch.ts
@@ -1,0 +1,7 @@
+import { RunSchema, type Run } from './run';
+
+/** @deprecated Renamed to `RunSchema`, which describes the same shape. This alias is removed in the next major version. */
+export const PerformBatchSchema = RunSchema;
+
+/** @deprecated Renamed to `Run`, which describes the same shape. This alias is removed in the next major version. */
+export type PerformBatch = Run;


### PR DESCRIPTION
Cuts v2.2.0 from what is already on master. `feat/schema-mismatch` is not in it.

## Why a minor

Three things in this release change types rather than add them, and only one of them is this client's contract to keep.

The enum-shaped types are open now: `Color`, `CardAging` and the rest end in `| (string & {})`, so an exhaustive `switch` with no `default` stops type-checking. The set of values belongs to Trello. The `_light` / `_dark` label shades reached the live API long before the spec named them and broke `getBoardCards` for everyone until v2.1.6 added the 30 by hand, and the same thing will happen again with some other list. A wrapper that promises a closed set is promising something it does not control, so widening it is not counted as breaking this client's contract. The changelog section opens with that warning so nobody meets it as a mystery build failure.

Four parameters narrowed from `unknown[]` to `AttachmentFields[]` and `string[]`. That is a wrong type corrected, and it stays.

The third one is a real break, and it is repaired here rather than shipped.

## PerformBatch comes back deprecated

`PerformBatch` and `PerformBatchSchema` stopped being emitted once the batch body resolved to the identical `Run` component. They are reachable only through `trello.js/parameters`, since the root barrel re-exports `api` and `models` and not `parameters`, so losing them would have been a silent removal from the only path that had them.

They are now generated as `@deprecated` aliases of `Run` and `RunSchema`, declarations rather than a re-export so the strikethrough survives into `dist/parameters/performBatch.d.ts`:

```ts
/** @deprecated Renamed to `RunSchema`, which describes the same shape. This alias is removed in the next major version. */
export declare const PerformBatchSchema: import("zod").ZodObject<{ urls: import("zod").ZodString }, ...>;
/** @deprecated Renamed to `Run`, which describes the same shape. This alias is removed in the next major version. */
export type PerformBatch = Run;
```

Both have carried `@deprecated` since v2.1.2, so the removal has been announced for two releases and now happens in a major, where it belongs.

Measured against the v2.1.6 tag, the public surface goes from 680 exported names to 691, and nothing is removed. The eleven added are the five board-export parameter types with their schemas, plus `openEnum`.

## Also in the release

Board exports, five endpoints the spec documents and this client never exposed. The three workspace fields Trello returns and documents nowhere, which had the nightly `schema-audit` red for three nights. `openEnum` exported from `trello.js/core`. `createTrelloClient` and `createClient` accepting an already-built `Client`.

## Verification

`pnpm run build`, `pnpm run lint`, `pnpm run check:attw` and 172 unit tests pass. The changelog heading matches the pattern `publish.yml` greps for, so the GitHub release body will not come out empty.

After merge the tag goes up separately: `git tag v2.2.0 && git push origin v2.2.0`.
